### PR TITLE
feat: Add API route for retrieving materials

### DIFF
--- a/src/app/api/materials/route.js
+++ b/src/app/api/materials/route.js
@@ -1,0 +1,21 @@
+import { connect } from "@/lib/db"
+import Material from "@/models/material"
+
+export async function GET(request) {
+	const limit = request.nextUrl.searchParams.get("limit") || 10
+	const offset = request.nextUrl.searchParams.get("offset") || 0
+
+	try {
+		await connect()
+		const materials = await Material.find().limit(limit).skip(offset)
+		return Response.json({
+			url: request.url,
+			next: materials.length ? `${request.url}?limit=${limit}&offset=${parseInt(offset) + parseInt(limit)}` : null,
+			prev: offset > 0 ? `${request.url}?limit=${limit}&offset=${parseInt(offset) - parseInt(limit)}` : null,
+			results: materials,
+		})
+	} catch (error) {
+		console.error(error)
+		return Response.json({ error: error.message }, { status: 500 })
+	}
+}

--- a/src/app/dashboard/materials/page.js
+++ b/src/app/dashboard/materials/page.js
@@ -1,0 +1,22 @@
+"use client"
+
+import useAxios from "@/hooks/use-axios"
+
+export default function Page() {
+	const { data, loading, error } = useAxios("/api/materials")
+
+	return (
+		<>
+			<h1>Materialer</h1>
+			{loading && <p>Loading...</p>}
+			{error && <p>Error: {error.message}</p>}
+			{data && (
+				<ul>
+					{data.results.map(material => (
+						<li key={material._id}>{material.name}</li>
+					))}
+				</ul>
+			)}
+		</>
+	)
+}

--- a/src/app/dashboard/materials/page.js
+++ b/src/app/dashboard/materials/page.js
@@ -1,22 +1,30 @@
 "use client"
 
 import useAxios from "@/hooks/use-axios"
+import { Button } from "@nextui-org/react"
+import { FaPen, FaTrash } from "react-icons/fa"
 
 export default function Page() {
 	const { data, loading, error } = useAxios("/api/materials")
 
 	return (
-		<>
+		<section className="px-4">
 			<h1>Materialer</h1>
 			{loading && <p>Loading...</p>}
 			{error && <p>Error: {error.message}</p>}
 			{data && (
 				<ul>
 					{data.results.map(material => (
-						<li key={material._id}>{material.name}</li>
+						<li key={material._id} className="flex justify-between odd:bg-gray-200">
+							{material.name}
+							<div>
+								<Button size="small" variant="light"><FaPen/></Button>
+								<Button size="small" variant="light"><FaTrash/></Button>
+							</div>
+						</li>
 					))}
 				</ul>
 			)}
-		</>
+		</section>
 	)
 }

--- a/src/app/dashboard/new-material/page.js
+++ b/src/app/dashboard/new-material/page.js
@@ -1,0 +1,55 @@
+"use client"
+
+import { createMaterial } from "@/lib/actions"
+import { Button, Input } from "@nextui-org/react"
+import { useRouter } from "next/navigation"
+import { useEffect } from "react"
+import { useFormState, useFormStatus } from "react-dom"
+import { FaSpinner } from "react-icons/fa"
+import { toast } from "react-toastify"
+
+export default function Page() {
+	const [errorMessage, dispatch] = useFormState(createMaterial, null)
+	const router = useRouter()
+
+	useEffect(function() {
+		if (errorMessage === true) {
+			router.push("/dashboard/materials")
+		} else if (errorMessage) {
+			toast.error(errorMessage)
+		}
+	}, [errorMessage])
+
+	return (
+		<section className="px-4">
+			<h1>Nyt materiale</h1>
+			<form action={dispatch}>
+				<Input label="Materialenavn" name="name" />
+				<Input label="Materialekategori" name="category" />
+				<Input type="number" label="Produktionsomkostninger" name="production_cost" />
+				<Input type="number" label="Brugsomkostninger" name="usage_cost" />
+				<Input type="number" label="Bortskaffelsesomkostninger" name="destruction_cost" />
+				<SubmitButton />
+			</form>
+		</section>
+	)
+}
+
+function SubmitButton() {
+	const {pending} = useFormStatus()
+
+	function handleClick(event) {
+		if (pending) {
+			event.preventDefault()
+		}
+	}
+
+	return (<Button
+		color="primary"
+		type="submit"
+		className="w-full mt-4"
+		aria-disabled={pending}
+		onClick={handleClick}>
+		Opret materiale {pending && <FaSpinner className="animate-spin" size={16}/>}
+	</Button>)
+}

--- a/src/app/dashboard/new-material/page.js
+++ b/src/app/dashboard/new-material/page.js
@@ -24,11 +24,11 @@ export default function Page() {
 		<section className="px-4">
 			<h1>Nyt materiale</h1>
 			<form action={dispatch}>
-				<Input label="Materialenavn" name="name" />
-				<Input label="Materialekategori" name="category" />
-				<Input type="number" label="Produktionsomkostninger" name="production_cost" />
-				<Input type="number" label="Brugsomkostninger" name="usage_cost" />
-				<Input type="number" label="Bortskaffelsesomkostninger" name="destruction_cost" />
+				<Input label="Materialenavn" name="name" variant="underlined" isRequired />
+				<Input label="Materialekategori" name="category" variant="underlined" isRequired />
+				<Input type="number" label="Produktionsomkostninger" name="production_cost" variant="underlined" isRequired />
+				<Input type="number" label="Brugsomkostninger" name="usage_cost" variant="underlined" isRequired />
+				<Input type="number" label="Bortskaffelsesomkostninger" name="destruction_cost" variant="underlined" isRequired />
 				<SubmitButton />
 			</form>
 		</section>

--- a/src/hooks/use-axios.js
+++ b/src/hooks/use-axios.js
@@ -5,13 +5,14 @@ import axios from "axios"
 export default function useAxios(endpoint) {
 	const [loading, setLoading] = useState(true)
 	const [data, setData] = useState(null)
+	const [error, setError] = useState(null)
 
 	useEffect(function () {
 		axios.get(endpoint)
 			.then(response => setData(response.data))
-			.catch(error => {throw new Error(error)})
+			.catch(error => {setError(error)})
 			.finally(() => setLoading(false))
 	}, [])
 
-	return { loading, data }
+	return { loading, data, error }
 }

--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -3,7 +3,8 @@
 import { connect } from "./db"
 import User from "@/models/user"
 import { cookies } from "next/headers"
-import { encrypt } from "@/lib/crypt"
+import { decrypt, encrypt } from "@/lib/crypt"
+import Material from "@/models/material"
 
 export async function authenticate(_currentState, formData) {
 	const username = formData.get("username")
@@ -25,6 +26,28 @@ export async function authenticate(_currentState, formData) {
 		return true
 	} catch (error) {
 		console.log(error)
+		return error.message
+	}
+}
+
+export async function createMaterial(_currentState, formData) {
+	const user = cookies().get("session")?.value
+	if (!user || decrypt(user) !== "admin") return "Du har ikke adgang til denne funktion"
+
+	const material = {
+		name: formData.get("name"),
+		category: formData.get("category"),
+		production_cost: formData.get("production_cost"),
+		usage_cost: formData.get("usage_cost"),
+		destruction_cost: formData.get("destruction_cost"),
+		//image: formData.get("image"),
+	}
+	try {
+		await connect()
+		await new Material(material).save()
+		return true
+	} catch (error) {
+		console.error(error)
 		return error.message
 	}
 }

--- a/src/models/material.js
+++ b/src/models/material.js
@@ -1,0 +1,33 @@
+import { Schema, model, models } from "mongoose"
+
+const materialSchema = new Schema({
+	name: {
+		type: String,
+		required: true,
+	},
+	category: {
+		type: String,
+		required: true,
+	},
+	production_cost: {
+		type: Number,
+		required: true,
+	},
+	usage_cost: {
+		type: Number,
+		required: true,
+	},
+	destruction_cost: {
+		type: Number,
+		required: true,
+	},
+	/* image: {
+		type: String,
+		required: true,
+	}, */
+}, {
+	timestamps: true,
+})
+
+const Material = models.Material || model("Material", materialSchema)
+export default Material


### PR DESCRIPTION
This commit adds a new API route `/api/materials` for retrieving materials. The `GET` function in the `route.js` file connects to the database, retrieves materials based on the provided limit and offset parameters, and returns a JSON response with the materials. This API route will be used in the `materials` page component to fetch and display the materials.

This PR belongs to issue #8 